### PR TITLE
Initialize FastAPI and Next.js scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+node_modules/
+.next/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# timetracking
+# Timetracking
+
+This repository contains a minimal scaffold for a time tracking application for a construction company.
+
+## Structure
+
+- `backend/` – FastAPI service with in-memory storage and tests.
+- `frontend/` – Next.js frontend that fetches time entries from the backend.
+
+## Backend
+
+```bash
+pip install -r backend/requirements.txt
+pytest backend
+uvicorn backend.main:app --reload
+```
+
+## Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The frontend expects the backend to run on `http://localhost:8000`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,38 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from datetime import date, time
+from typing import List, Optional
+
+app = FastAPI(title="Timetracking API")
+
+class Expense(BaseModel):
+    type: str
+    amount: float
+    note: Optional[str] = None
+
+class TimeEntry(BaseModel):
+    id: int
+    user_id: int
+    site_id: int
+    date: date
+    start_time: time
+    end_time: time
+    lunch_flat_applied: bool = False
+    travel_minutes: int = 0
+    expenses: List[Expense] = []
+
+entries: List[TimeEntry] = []
+
+@app.get("/time-entries", response_model=List[TimeEntry])
+def list_entries() -> List[TimeEntry]:
+    """Return all stored time entries."""
+    return entries
+
+@app.post("/time-entries", response_model=TimeEntry)
+def create_entry(entry: TimeEntry) -> TimeEntry:
+    """Create a new time entry in memory."""
+    if any(e.id == entry.id for e in entries):
+        raise HTTPException(status_code=400, detail="Duplicate entry ID")
+    entries.append(entry)
+    return entry
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn==0.29.0
+pydantic==2.6.4
+pytest==8.1.1
+httpx==0.27.0

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+from .main import app
+
+client = TestClient(app)
+
+
+def test_create_and_list_entries():
+    payload = {
+        "id": 1,
+        "user_id": 1,
+        "site_id": 1,
+        "date": "2024-01-01",
+        "start_time": "08:00:00",
+        "end_time": "16:00:00",
+        "lunch_flat_applied": False,
+        "travel_minutes": 0,
+        "expenses": []
+    }
+    response = client.post("/time-entries", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == 1
+
+    list_resp = client.get("/time-entries")
+    assert list_resp.status_code == 200
+    assert len(list_resp.json()) == 1

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "timetracking-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.3.3",
+    "@types/react": "18.2.21",
+    "@types/node": "20.11.19"
+  }
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+interface TimeEntry {
+  id: number;
+  user_id: number;
+  site_id: number;
+  date: string;
+  start_time: string;
+  end_time: string;
+  lunch_flat_applied: boolean;
+  travel_minutes: number;
+}
+
+export default function Home() {
+  const [entries, setEntries] = useState<TimeEntry[]>([]);
+
+  useEffect(() => {
+    fetch('http://localhost:8000/time-entries')
+      .then(res => res.json())
+      .then(setEntries)
+      .catch(() => setEntries([]));
+  }, []);
+
+  return (
+    <main>
+      <h1>Time Entries</h1>
+      <ul>
+        {entries.map(e => (
+          <li key={e.id}>
+            {e.date}: {e.start_time} - {e.end_time} (travel {e.travel_minutes} min)
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add FastAPI backend with in-memory time entry endpoints
- scaffold Next.js frontend fetching time entries
- document setup and add .gitignore

## Testing
- `pip install -r backend/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest backend` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a4d17cad908329aa10794b9fd217a5