### PR TITLE
Handle frontend backend errors

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -13,17 +13,22 @@ interface TimeEntry {
 
 export default function Home() {
   const [entries, setEntries] = useState<TimeEntry[]>([]);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     fetch('http://localhost:8000/time-entries')
       .then(res => res.json())
       .then(setEntries)
-      .catch(() => setEntries([]));
+      .catch(() => {
+        setError(true);
+        setEntries([]);
+      });
   }, []);
 
   return (
     <main>
       <h1>Time Entries</h1>
+      {error && <p>Backend nicht erreichbar</p>}
       <ul>
         {entries.map(e => (
           <li key={e.id}>


### PR DESCRIPTION
## Summary
- add error state to frontend Time Entries page
- display fallback text when the backend cannot be reached

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4f3fe44988329ac93dd6bf5bfdad0