### PR TITLE
Use env variable for API base URL in frontend

### DIFF
--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -15,7 +15,7 @@ export default function Home() {
   const [entries, setEntries] = useState<TimeEntry[]>([]);
 
   useEffect(() => {
-    fetch('http://localhost:8000/time-entries')
+    fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/time-entries`)
       .then(res => res.json())
       .then(setEntries)
       .catch(() => setEntries([]));


### PR DESCRIPTION
## Summary
- configure `NEXT_PUBLIC_API_BASE_URL` via `.env.local`
- fetch time entries using the configured base URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4f3ff90e88329b4be1e5f7d11b969